### PR TITLE
Add Github Action to Deploy to Web Stores

### DIFF
--- a/.github/workflows/deploy_to_stores.yml
+++ b/.github/workflows/deploy_to_stores.yml
@@ -1,0 +1,27 @@
+on: workflow_dispatch
+
+name: Submit to Web Store
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+      - uses: actions/cache@v2
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - name: Build
+        run: make build
+      - name: "Browser Plugin Publish"
+        uses: plasmo-corp/bpp@v1
+        with:
+          artifact: "./build/manabaEnhanced-{version}.zip"
+          keys: ${{ secrets.SUBMIT_KEYS }}


### PR DESCRIPTION
Hey @mkobayashime, we created a [Github action](https://github.com/marketplace/actions/browser-plugin-publisher) to make it easier to publish extensions to the various web stores.

I thought you might find it useful so I added a Github workflow that will build the extension, zip it up, and publish to the web stores on dispatch.

The only thing you would need to create is a `SUBMIT_KEYS` GitHub repository secret.

This secret is a JSON, with the schema defined [here](https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json).

Here's a sample key:

```
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "clientId": "123",
    "clientSecret": "456",
    "refreshToken": "789",
    "extId": "abcd"
  }
}
```
You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me.

Otherwise, if this doesn't seem necessary, feel free to close the PR!

(p.s. this is one of the few browser extensions I've seen that actually uses Webpack to perform the Zip step! Nice one!)