### PR TITLE
fix: correct the specification of the deadline

### DIFF
--- a/src/methods/ReportTemplateGenerator.ts
+++ b/src/methods/ReportTemplateGenerator.ts
@@ -144,7 +144,7 @@ class ReportInfo {
     ".stdlist-reportV2 td"
   )
   private descriptionElement = this.tdElements[0]
-  private deadlineElement = this.tdElements[1]
+  private deadlineElement = this.tdElements[2]
 }
 
 export { ReportTemplateGenerator }


### PR DESCRIPTION
This PR fixes the specification of the deadline and is a fix for #450 .

### Before
The report template is rendered using the `start` element.

### After
The report template is rendered using the `end` element.