### PR TITLE
chore: generate release notes automatically

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - Masaki Kobayashi
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - Semver-Major
+        - breaking-change
+    - title: Exciting New Features 🎉
+      labels:
+        - Semver-Minor
+        - enhancement
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
Automatically generated release notes[^1] aid in writing release notes.

[^1]: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes